### PR TITLE
CoreDataUtility changes: open links, copy cell, right-click select row, show boolean values, date changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ xcuserdata
 profile
 *.moved-aside
 DerivedData
+
+# IDEA (IntelliJ/AppCode) settings
+.idea


### PR DESCRIPTION
- add right-click menu option to 'copy cell' which will copy the text of a cell into clipboard (only appears if 1 row is selected)
- on right-click of a non-selected row, select that row (fixes weird behavior where a row is selected but you right-click on another row. the menu option selected applies to the selected row even though the popup box appears over the non-selected row)
- add a button to the cell for String values that start with "http". clicking on the button will open in browser/default handler
- add a button to the cell for NSURL values. clicking on the button will open in browser/default handler
- show "YES" or "NO" for Boolean data types (shows 1 or 0 now)
- move NSDateFormatter creation so it's only created once and re-used for all cells
- change definition of 'short' and 'medium' date formats to be a little more compact
- add .idea to .gitignore (AppCode project files)
